### PR TITLE
add missing includes

### DIFF
--- a/ImageHelper.hh
+++ b/ImageHelper.hh
@@ -26,6 +26,8 @@
 #ifndef ImageHelper_h 
 #define ImageHelper_h 1
 
+#include <string.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <iostream>
 

--- a/evg-thin.cc
+++ b/evg-thin.cc
@@ -22,6 +22,8 @@
 
 *********************************************************************/
 
+#include <string.h>
+#include <stdlib.h>
 #include "evg-thin.hh"
 #include "utils.hh"
 #include <iostream>

--- a/test.cc
+++ b/test.cc
@@ -23,6 +23,8 @@
 *********************************************************************/
 
 
+#include <string.h>
+#include <stdlib.h>
 #include <iostream>
 #include <float.h>
 #include <math.h>


### PR DESCRIPTION
The `make` command fails on modern systems. This PR adds missing include statements that allows the program to be installed. The solution is from [this](https://stackoverflow.com/questions/32980877/c-code-of-thinning-algorithm-evg-thin) post.